### PR TITLE
added fetchX smarty functions for db queries from template

### DIFF
--- a/Extensions/Fetch/Extension.php
+++ b/Extensions/Fetch/Extension.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace FroshTemplateExtensions\Extensions\Fetch;
+
+use FroshTemplateExtensions\Components\AbstractSmartyExtension;
+
+class Extension extends AbstractSmartyExtension
+{
+    /**
+     * @var FetchService
+     */
+    private $service;
+
+    public function __construct(FetchService $service)
+    {
+        $this->service = $service;
+    }
+
+    public function getFunctions()
+    {
+        return [
+            'fetchOne' => [$this, 'fetchOne'],
+            'fetchRow' => [$this, 'fetchRow'],
+            'fetchAll' => [$this, 'fetchAll'],
+        ];
+    }
+
+    public function fetchOne(array $params)
+    {
+        if (!isset($params['select'])) {
+            throw new \RuntimeException('Select is required');
+        }
+
+        $this->checkParams($params);
+
+        return $this->service->fetchOne($params);
+    }
+
+    public function fetchRow(array $params, \Smarty_Internal_Template $template)
+    {
+        if (!isset($params['select'])) {
+            $params['select'] = '*';
+        }
+
+        $this->checkParams($params);
+
+        if (!isset($params['var']) || !is_string($params['var'])) {
+            throw new \RuntimeException('Var parameter missing or must be of type string');
+        }
+
+        $template->assign($params['var'], $this->service->fetchRow($params));
+    }
+
+    public function fetchAll(array $params, \Smarty_Internal_Template $template)
+    {
+        if (!isset($params['select'])) {
+            $params['select'] = '*';
+        }
+
+        $this->checkParams($params);
+
+        if (isset($params['var']) && !is_string($params['var'])) {
+            throw new \RuntimeException('Var parameter missing or must be of type string');
+        }
+
+        $template->assign($params['var'], $this->service->fetchAll($params));
+    }
+
+    private function checkParams($params)
+    {
+        if (!is_string($params['select']) && !is_array($params['select'])) {
+            throw new \RuntimeException('Select must either be of type string or array');
+        }
+
+        if (!isset($params['from'])) {
+            throw new \RuntimeException('From table is required');
+        }
+
+        if (isset($params['where']) && !is_array($params['where'])) {
+            throw new \RuntimeException('Where parameter must be of type array');
+        }
+
+        if (isset($params['order']) && !is_array($params['order'])) {
+            throw new \RuntimeException('Order parameter must be of type array');
+        }
+
+        if (isset($params['offset']) && !is_int($params['offset'])) {
+            throw new \RuntimeException('Offset parameter must be of type integer');
+        }
+
+        if (isset($params['limit']) && !is_int($params['limit'])) {
+            throw new \RuntimeException('Limit parameter must be of type integer');
+        }
+    }
+}

--- a/Extensions/Fetch/Extension.php
+++ b/Extensions/Fetch/Extension.php
@@ -59,7 +59,7 @@ class Extension extends AbstractSmartyExtension
 
         $this->checkParams($params);
 
-        if (isset($params['var']) && !is_string($params['var'])) {
+        if (!isset($params['var']) || !is_string($params['var'])) {
             throw new \RuntimeException('Var parameter missing or must be of type string');
         }
 

--- a/Extensions/Fetch/FetchService.php
+++ b/Extensions/Fetch/FetchService.php
@@ -124,11 +124,12 @@ class FetchService implements FetchServiceInterface
 
         if (isset($arguments['where'])) {
             foreach ($arguments['where'] as $column => $value) {
+                $type = is_array($value) ? Connection::PARAM_STR_ARRAY : \PDO::PARAM_STR;
                 $qb->andWhere(
                     sprintf(
-                        '%s %s',
+                        is_array($value) ? '%s (%s)' : '%s %s',
                         $column,
-                        $qb->createNamedParameter($value)
+                        $qb->createNamedParameter($value, $type)
                     )
                 );
             }

--- a/Extensions/Fetch/FetchService.php
+++ b/Extensions/Fetch/FetchService.php
@@ -14,15 +14,23 @@ class FetchService implements FetchServiceInterface
     /**
      * @var array
      */
+    private $pluginConfig;
+
+    /**
+     * @var array
+     */
     private $_cache = [];
 
     /**
      * @param Connection $connection
+     * @param array      $pluginConfig
      */
     public function __construct(
-        Connection $connection
+        Connection $connection,
+        $pluginConfig
     ) {
         $this->connection = $connection;
+        $this->pluginConfig = $pluginConfig;
     }
 
     /**
@@ -32,6 +40,10 @@ class FetchService implements FetchServiceInterface
      */
     public function fetchOne($arguments)
     {
+        if (!$this->pluginConfig['fetch_functions_active']) {
+            return null;
+        }
+
         return $this->fetch(
             $arguments,
             'fetch',
@@ -46,6 +58,10 @@ class FetchService implements FetchServiceInterface
      */
     public function fetchRow($arguments)
     {
+        if (!$this->pluginConfig['fetch_functions_active']) {
+            return null;
+        }
+
         return $this->fetch(
             $arguments,
             'fetch',
@@ -60,6 +76,10 @@ class FetchService implements FetchServiceInterface
      */
     public function fetchAll($arguments)
     {
+        if (!$this->pluginConfig['fetch_functions_active']) {
+            return null;
+        }
+
         return $this->fetch(
             $arguments,
             'fetchAll',

--- a/Extensions/Fetch/FetchService.php
+++ b/Extensions/Fetch/FetchService.php
@@ -124,6 +124,12 @@ class FetchService implements FetchServiceInterface
 
         if (isset($arguments['where'])) {
             foreach ($arguments['where'] as $column => $value) {
+                if (is_null($value)) {
+                    $qb->andWhere($column);
+
+                    continue;
+                }
+
                 $type = is_array($value) ? Connection::PARAM_STR_ARRAY : \PDO::PARAM_STR;
                 $qb->andWhere(
                     sprintf(

--- a/Extensions/Fetch/FetchService.php
+++ b/Extensions/Fetch/FetchService.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace FroshTemplateExtensions\Extensions\Fetch;
+
+use Doctrine\DBAL\Connection;
+
+class FetchService implements FetchServiceInterface
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var array
+     */
+    private $_cache = [];
+
+    /**
+     * @param Connection $connection
+     */
+    public function __construct(
+        Connection $connection
+    ) {
+        $this->connection = $connection;
+    }
+
+    /**
+     * @param array $arguments
+     *
+     * @return mixed
+     */
+    public function fetchOne($arguments)
+    {
+        return $this->fetch(
+            $arguments,
+            'fetch',
+            \PDO::FETCH_COLUMN
+        );
+    }
+
+    /**
+     * @param array $arguments
+     *
+     * @return mixed
+     */
+    public function fetchRow($arguments)
+    {
+        return $this->fetch(
+            $arguments,
+            'fetch',
+            \PDO::FETCH_ASSOC
+        );
+    }
+
+    /**
+     * @param array $arguments
+     *
+     * @return mixed
+     */
+    public function fetchAll($arguments)
+    {
+        return $this->fetch(
+            $arguments,
+            'fetchAll',
+            \PDO::FETCH_ASSOC
+        );
+    }
+
+    /**
+     * @param array  $arguments
+     * @param string $method
+     * @param int    $fetchMode
+     *
+     * @return mixed
+     */
+    public function fetch($arguments, $method, $fetchMode)
+    {
+        $hash = md5($method . serialize($arguments));
+        $cache = $this->getCurrentStackCache($hash);
+
+        if ($cache) {
+            return $cache;
+        }
+
+        try {
+            $value = $this->getDbSelect($arguments)
+                ->execute()
+                ->$method($fetchMode);
+
+            $this->_cache[$hash] = $value;
+
+            return $value;
+        } catch (\Exception $exception) {
+            return $exception->getMessage();
+        }
+    }
+
+    /**
+     * @param string $hash
+     *
+     * @return bool|mixed
+     */
+    private function getCurrentStackCache($hash)
+    {
+        if (isset($this->_cache[$hash])) {
+            return $this->_cache[$hash];
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array  $arguments
+     *
+     * @return \Doctrine\DBAL\Query\QueryBuilder
+     */
+    private function getDbSelect($arguments)
+    {
+        $qb = $this->connection->createQueryBuilder();
+
+        $qb->select($arguments['select'])
+            ->from($arguments['from']);
+
+        if (isset($arguments['where'])) {
+            foreach ($arguments['where'] as $column => $value) {
+                $qb->andWhere(
+                    sprintf(
+                        '%s %s',
+                        $column,
+                        $qb->createNamedParameter($value)
+                    )
+                );
+            }
+        }
+
+        if (isset($arguments['order'])) {
+            foreach ($arguments['order'] as $column => $order) {
+                $qb->addOrderBy($column, $order);
+            }
+        }
+
+        if (isset($arguments['offset'])) {
+            $qb->setFirstResult($arguments['offset']);
+        }
+
+        if (isset($arguments['limit'])) {
+            $qb->setMaxResults($arguments['limit']);
+        }
+
+        return $qb;
+    }
+}

--- a/Extensions/Fetch/FetchServiceInterface.php
+++ b/Extensions/Fetch/FetchServiceInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace FroshTemplateExtensions\Extensions\Fetch;
+
+interface FetchServiceInterface
+{
+    /**
+     * @param array $arguments
+     *
+     * @return mixed
+     */
+    public function fetchOne($arguments);
+
+    /**
+     * @param array $arguments
+     *
+     * @return mixed
+     */
+    public function fetchRow($arguments);
+
+    /**
+     * @param array $arguments
+     *
+     * @return mixed
+     */
+    public function fetchAll($arguments);
+
+    /**
+     * @param array  $arguments
+     * @param string $method
+     * @param int    $fetchMode
+     *
+     * @return mixed
+     */
+    public function fetch($arguments, $method, $fetchMode);
+}

--- a/Extensions/Fetch/services.xml
+++ b/Extensions/Fetch/services.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="FroshTemplateExtensions\Extensions\Fetch\Extension" class="FroshTemplateExtensions\Extensions\Fetch\Extension">
+            <argument type="service" id="FroshTemplateExtensions\Extensions\Fetch\FetchService"/>
+            <tag name="frosh.smarty_plugin"/>
+        </service>
+
+        <service id="FroshTemplateExtensions\Extensions\Fetch\FetchService" class="FroshTemplateExtensions\Extensions\Fetch\FetchService">
+            <argument type="service" id="dbal_connection"/>
+        </service>
+    </services>
+</container>

--- a/Extensions/Fetch/services.xml
+++ b/Extensions/Fetch/services.xml
@@ -11,6 +11,7 @@
 
         <service id="FroshTemplateExtensions\Extensions\Fetch\FetchService" class="FroshTemplateExtensions\Extensions\Fetch\FetchService">
             <argument type="service" id="dbal_connection"/>
+            <argument type="service" id="FroshTemplateExtensions\PluginConfig"/>
         </service>
     </services>
 </container>

--- a/FroshTemplateExtensions.php
+++ b/FroshTemplateExtensions.php
@@ -42,5 +42,6 @@ class FroshTemplateExtensions extends Plugin
         );
 
         $loader->load($this->getPath() . '/Extensions/Thumbnail/services.xml');
+        $loader->load($this->getPath() . '/Extensions/Fetch/services.xml');
     }
 }

--- a/FroshTemplateExtensions.php
+++ b/FroshTemplateExtensions.php
@@ -34,6 +34,8 @@ class FroshTemplateExtensions extends Plugin
 {
     public function build(ContainerBuilder $container)
     {
+        parent::build($container);
+
         $container->addCompilerPass(new CustomTemplateFactory());
 
         $loader = new XmlFileLoader(

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Examples
 {* Fetches the price of the last article added to basket of the current user *}
 {fetchOne select="price" from="s_order_basket" where=["modus =" => 0, "sessionID =" => $smarty.session.Shopware.sessionId] order=["id" => "DESC"]}
 
-{* Fetches the name and description of the 5th to 15th article *}
+{* Fetches the 5th to 15th row of s_articles *}
 {fetchAll var="articles" from="s_articles" offset=5 limit=10}
 {foreach $articles as $article}
     Article: {$article.name} - {$article.description}<br>
@@ -66,6 +66,10 @@ Examples
 {fetchRow var="order" select=["ordernumber", "id"] from="s_order" where=["status !=" => -1] order=["ordertime" => "DESC"]}
 {$order.id} - {$order.ordernumber}
 ```
+
+*Please note:* The fetch functions need to be actived through the configuration of the plugin. They are disabled by default. 
+Before activating the fetch functions, please make sure, that none of your changes to your theme allow for unsanitized user 
+inputs to be compiled as smarty.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,40 @@ Examples
 <img src="{thumbnail path=media/image/foo.png width=1920 height=1920}">
 ```
 
+### Fetch
+
+Fetch data from the database using the functions:
+
+* `fetchOne` - fetches a single value from the specified column of a row
+* `fetchRow` - fetches the first row from the specified table
+* `fetchAll` - fetches all rows from the specified table
+
+The following parameters are available
+
+* `var` - required for `fetchRow` and `fetchAll`, defines the variable the resulting array will be stored in
+* `select` - may either be of type `string` or `array`, specifies the columns to be fetch, required for `fetchOne`
+* `from` - required for all functions, specifies the table to be fetched from
+* `where` - must be of type `array`, must contain key value pairs in the format of `'[column][operand]' => value` 
+* `order` - must be of type `array`, must contain key value pairs in the format of `'[column]' => '[ASC][DESC]'` 
+* `offset` - must be of type `integer`, sets the offset for the first result
+* `limit` - must be of type `integer`, sets the limit of results
+
+Examples
+
+```smarty
+{* Fetches the price of the last article added to basket of the current user *}
+{fetchOne select="price" from="s_order_basket" where=["modus =" => 0, "sessionID =" => $smarty.session.Shopware.sessionId] order=["id" => "DESC"]}
+
+{* Fetches the name and description of the 5th to 15th article *}
+{fetchAll var="articles" from="s_articles" offset=5 limit=10}
+{foreach $articles as $article}
+    Article: {$article.name} - {$article.description}<br>
+{/foreach}
+
+{* Fetches the last order's id and ordernumber *}
+{fetchRow var="order" select=["ordernumber", "id"] from="s_order" where=["status !=" => -1] order=["ordertime" => "DESC"]}
+{$order.id} - {$order.ordernumber}
+```
 
 ## Requirements
 

--- a/Resources/config.xml
+++ b/Resources/config.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../engine/Shopware/Components/Plugin/schema/config.xsd">
+    <elements>
+        <element type="boolean">
+            <name>fetch_functions_active</name>
+            <label lang="de">Fetch Funktionen sind aktiv</label>
+            <label lang="en">Fetch functions are active</label>
+            <value>false</value>
+            <description lang="de">
+                <![CDATA[
+                    Stelle bitte vor der Aktivierung der Fetch Funktionen sicher, dass durch Anpassungen in deinem Theme
+                    keine ungefilterten Nutzereingaben als Smarty kompiliert werden können.
+                ]]>
+            </description>
+            <description lang="en">
+                <![CDATA[
+                    Before activating the fetch functions, please make sure, that none of your changes to your theme allow
+                    for unsanitized user inputs to be compiled as smarty.
+                ]]>
+            </description>
+        </element>
+    </elements>
+</config>

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="FroshTemplateExtensions\PluginConfig" class="Shopware\Components\Plugin\CachedConfigReader">
+            <factory service="shopware.plugin.cached_config_reader" method="getByPluginName"/>
+            <argument type="string">FroshTemplateExtensions</argument>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
Fetch data from the database using the smarty functions:

* `fetchOne` - fetches a single value from the specified column of a row
* `fetchRow` - fetches the first row from the specified table
* `fetchAll` - fetches all rows from the specified table

The following parameters are available

* `var` - required for `fetchRow` and `fetchAll`, defines the variable the resulting array will be stored in
* `select` - may either be of type `string` or `array`, specifies the columns to be fetch, required for `fetchOne`
* `from` - required for all functions, specifies the table to be fetched from
* `where` - must be of type `array`, must contain key value pairs in the format of `'[column][operand]' => value` 
* `order` - must be of type `array`, must contain key value pairs in the format of `'[column]' => '[ASC][DESC]'` 
* `offset` - must be of type `integer`, sets the offset for the first result
* `limit` - must be of type `integer`, sets the limit of results

Examples

```smarty
{* Fetches the price of the last article added to basket of the current user *}
{fetchOne select="price" from="s_order_basket" where=["modus =" => 0, "sessionID =" => $smarty.session.Shopware.sessionId] order=["id" => "DESC"]}

{* Fetches the name and description of the 5th to 15th article *}
{fetchAll var="articles" from="s_articles" offset=5 limit=10}
{foreach $articles as $article}
    Article: {$article.name} - {$article.description}<br>
{/foreach}

{* Fetches the last order's id and ordernumber *}
{fetchRow var="order" select=["ordernumber", "id"] from="s_order" where=["status !=" => -1] order=["ordertime" => "DESC"]}
{$order.id} - {$order.ordernumber}
```